### PR TITLE
Eval cleanup

### DIFF
--- a/autogluon_benchmark/aggregate/results.py
+++ b/autogluon_benchmark/aggregate/results.py
@@ -9,7 +9,7 @@ def aggregate_results(s3_bucket,
                       constraint,
                       include_infer_speed=False,
                       mode='ray'):
-    contains = f'.{constraint}.'
+    contains = f'.{constraint}.' if constraint else None
     result_path = f'{s3_prefix}{version_name}/'
     path_prefix = f's3://{s3_bucket}/{result_path}'
 

--- a/autogluon_benchmark/benchmark_context/_output_suite_context.py
+++ b/autogluon_benchmark/benchmark_context/_output_suite_context.py
@@ -1,7 +1,6 @@
 import copy
 from typing import List, Optional, Set
 
-import numpy as np
 import pandas as pd
 import ray
 

--- a/autogluon_benchmark/evaluation/evaluator/benchmark_evaluator.py
+++ b/autogluon_benchmark/evaluation/evaluator/benchmark_evaluator.py
@@ -152,6 +152,7 @@ class BenchmarkEvaluator:
                   folds: list = None,
                   clean_data: bool = False,
                   problem_type=None,
+                  valid_datasets: list = None,
                   banned_datasets: list = None,
                   infer_batch_size: int = None,
                   treat_folds_as_datasets: bool = False,
@@ -167,6 +168,8 @@ class BenchmarkEvaluator:
             print(f'Filtering to the following problem_type: {problem_type}')
         if banned_datasets is not None:
             results_raw = results_raw[~results_raw[DATASET].isin(banned_datasets)]
+        if valid_datasets is not None:
+            results_raw = results_raw[results_raw[DATASET].isin(valid_datasets)]
         if self._use_tid_as_dataset_name:
             results_raw[DATASET] = results_raw['tid'].astype(int).astype(str)
             if banned_datasets is not None:
@@ -186,6 +189,7 @@ class BenchmarkEvaluator:
             frameworks_present = list(results_raw[FRAMEWORK].unique())
             if set(frameworks) != set(frameworks_present):
                 diff = list(set(frameworks).symmetric_difference(set(frameworks_present)))
+                diff = sorted(diff)
                 raise AssertionError(f'Difference in expected frameworks present: {diff}')
         # Round error
         results_raw[METRIC_ERROR] = results_raw[METRIC_ERROR].round(decimals=4)
@@ -194,8 +198,11 @@ class BenchmarkEvaluator:
             results_raw = results_raw[self._columns_to_keep]
         return results_raw
 
+    def _load_task_metadata(self) -> pd.DataFrame:
+        return load_task_metadata(path=self._task_metadata_path)
+
     def _clean_data(self, results_raw):
-        task_metadata = load_task_metadata(path=self._task_metadata_path)
+        task_metadata = self._load_task_metadata()
         task_metadata[DATASET] = task_metadata['name']
         # FIXME: TEMP
         results_raw = results_raw.drop(columns=[DATASET])
@@ -242,3 +249,16 @@ class BenchmarkEvaluator:
 
     def _filter_frameworks(self, results_raw: pd.DataFrame, frameworks: list):
         return results_raw[results_raw['framework'].isin(frameworks)]
+
+    def filter_datasets(self, *, max_rows=None, min_rows=None, max_rows_missing_val=None, max_features_categorical=None):
+        # TODO: Consider having task_metadata be its own class
+        task_metadata = self._load_task_metadata()
+
+        if max_rows is not None:
+            task_metadata = task_metadata[task_metadata['NumberOfInstances'] <= max_rows]
+        if max_rows_missing_val is not None:
+            task_metadata = task_metadata[task_metadata['NumberOfInstancesWithMissingValues'] <= max_rows_missing_val]
+        if max_features_categorical is not None:
+            task_metadata = task_metadata[task_metadata['NumberOfSymbolicFeatures'] <= max_features_categorical]
+
+        return list(task_metadata['name'])

--- a/autogluon_benchmark/evaluation/runners/run_evaluation_openml.py
+++ b/autogluon_benchmark/evaluation/runners/run_evaluation_openml.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
 import argparse
+from typing import Dict, List
+
+import pandas as pd
 
 from autogluon_benchmark.evaluation import evaluate_results
 from autogluon_benchmark.evaluation.constants import TIME_INFER_S
@@ -6,22 +11,122 @@ from autogluon_benchmark.evaluation.evaluate_utils import compute_stderr_z_stat,
 from autogluon_benchmark.evaluation import BenchmarkEvaluator
 
 
+# TODO: Rename to a more description function, or convert to a class
 def run(
     *,
-    frameworks_run,
-    paths,
-    output_suffix='ag_full_v5/1h8c',
-    framework_nan_fill=None,
-    problem_type=None,
-    folds_to_keep: list = None,
-    compute_z_score=True,
-    treat_folds_as_datasets=False,
-    banned_datasets=None,
-    infer_batch_size=None,
-    clean_data=True,
-    use_tid_as_dataset_name=True,
-    filter_errors=False,  # If True, all dataset errors will be filtered out
-):
+    frameworks_run: List[str],
+    paths: List[str],
+    output_suffix: str = 'ag_full_v5/1h8c',
+    framework_nan_fill: str | None = None,
+    problem_type: List[str] | str | None = None,
+    folds_to_keep: List[int] | None = None,
+    compute_z_score: bool = True,
+    treat_folds_as_datasets: bool = False,
+    banned_datasets: List[str] | None = None,
+    infer_batch_size: int | None = None,
+    clean_data: bool = True,
+    use_tid_as_dataset_name: bool = True,
+    filter_errors: bool = False,
+) -> (pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame, Dict[str, pd.DataFrame]):
+    """
+    # TODO: Add description
+
+    Parameters
+    ----------
+    frameworks_run : List[str]
+        The list of frameworks to compare.
+        These frameworks must be present in the "frameworks" column of the loaded input files listed in the `paths` arg.
+    paths : List[str]
+        The list of file paths to load the input data from.
+        The resulting input DataFrame will be the concatenation of all files listed in `paths`.
+        Filepaths can include files located in s3 assuming you have the proper read permissions.
+        # TODO: Define each column that must exist in paths
+        # TODO: Consider allowing non-preprocessed data that is preprocessed on-the-fly for convenience
+        # TODO: Allow passing the raw results DataFrame directly rather than requiring always loading from paths.
+    output_suffix : str
+        The output suffix of the path to save the output files.
+        # TODO: Expand this description, add more control over save locations, add option to avoid saving entirely
+    framework_nan_fill : str, optional
+        The framework used as the default result to fill missing values for the frameworks in `frameworks_run`.
+        For example, if `framework_nan_fill='foo'`, for dataset A if `framework='bar'` has no result (or NaN result),
+        it is replaced by the result of `'foo'` on dataset A.
+        A common usage of this is to specify some simple baseline, such as a constant predictor or dummy model.
+    problem_type : List[str] | str, optional, default None
+        The list of problem types to filter results to. By default, all problem types are used, and no filtering occurs.
+    folds_to_keep : List[int], optional
+        The list of result folds to use. All others are dropped. By default folds 0-9 (10-fold) are used.
+        More folds leads to greater statistical certainty.
+    compute_z_score : bool, default True
+        Whether to compute comparison z-scores. The framework being compared against is the first one listed in `frameworks_run`.
+        Only valid when multiple folds are used and `treat_folds_as_datasets=False`.
+    treat_folds_as_datasets : bool, default False
+        If True, all dataset x fold results are treated as their own separate datasets,
+        rather than averaging the fold results together.
+    banned_datasets : List[str], optional
+        If specified, the list of datasets are filtered from the datasets used in evaluation.
+    infer_batch_size : int, optional
+        If specified, will replace the `time_infer_s` column with the value in column `pred_time_test_with_transform_batch_size_{infer_batch_size}`
+        If a given row does not have a value in the infer_batch_size column, the original `time_infer_s` value is used.
+    clean_data : bool, default True
+        If True, performs some general data cleanup to avoid inconsistencies in dataset naming compared to task ids.
+        If True, `time_infer_s` is updated to be the time per row, rather than the overall time.
+        Must be set to False if using results that don't contain tids or lack a task metadata file.
+    use_tid_as_dataset_name : bool, default False
+        If True, replaces dataset human-readable names with unique integer IDs associated with their OpenML task ID.
+    filter_errors : bool, default False
+        If True, any dataset missing a result from any framework in `frameworks_run` will be filtered from all results.
+        This ensures a dense result evaluation, but may lead to many datasets being filtered due to sparse framework failures.
+        If True, takes priority over `framework_nan_fill`.
+
+    Returns
+    -------
+    results_ranked : pd.DataFrame
+        A pandas DataFrame with 1 row per framework in `frameworks_run`.
+        Includes a variety of analytics of overall performance aggregated across datasets.
+        This result only contains datasets where all frameworks succeeded.
+        This is the aggregated form of `results_ranked_by_dataset`.
+
+        Default column names:
+        ['framework', 'time_train_s', 'metric_error', 'time_infer_s', 'bestdiff', 'loss_rescaled',
+        'time_train_s_rescaled', 'time_infer_s_rescaled',
+        'rank', 'rank=1_count', 'rank=2_count', 'rank=3_count', 'rank>3_count', 'error_count']
+
+        Column Definitions
+            framework : The name of the framework
+            time_train_s : The mean training time in seconds
+            time_infer_s : The mean inference time in seconds (per row if clean_data=True)
+            bestdiff : The mean percentage relative less errors the best framework on a given dataset has compared to this framework.
+                If the framework is the best for a given dataset, then the bestdiff value on that dataset is 0.
+                If the best framework gets 0.05 metric_error, and framework FOO gets 0.20 metric_error,
+                    then bestdiff for this dataset is 0.75 for FOO because (0.20 - 0.05)/0.20 = 0.75
+                    (aka FOO has 4x more error than the best framework, and the best framework has 75% less error than FOO)
+                0 is the best, 1 is the worst.
+            loss_rescaled : The mean rescaled version of `metric_error`, where the best framework is rescaled to 0 and the worst framework is rescaled to 1 for each dataset.
+                0 is the best, 1 is the worst.
+            *_rescaled : The mean rescaled version of the original column, where the fastest framework for each dataset is rescaled to 1.
+            rank : mean rank
+            rank=1_count : number of undisputed first-place (champion) datasets
+            rank=2_count : number of second-place datasets (or 2-way tie for 1st place) (rank >1, <=2)
+            rank=3_count : number of third-place datasets (rank >2, <=3)
+            rank>3_count : number of datasets with placement worse than 3rd.
+            error_count : number of failed datasets with no result.
+    results_ranked_all : pd.DataFrame
+        Identical to `results_ranked`, except it also includes datasets where a subset of frameworks failed.
+    results_ranked_by_dataset : pd.DataFrame
+        A pandas DataFrame with N rows per framework, where N is the number of datasets.
+        This result contains evaluations on a per-dataset granularity.
+        `results_ranked` is the aggregated form of this result.
+
+        # TODO: Define each column
+    results_ranked_by_dataset_all : pd.DataFrame
+        Identical to `results_ranked_by_dataset`, except it also includes datasets where a subset of frameworks failed.
+    results_pairs_merged_dict : Dict[str, pd.DataFrame]
+        For each framework that was pair-wise compared with other frameworks, the key is the framework name,
+        and the value is a pandas DataFrame of the comparison evaluation results.
+        In general, only the first framework in `frameworks_run` is pair-wise compared.
+
+        # TODO: Define each column
+    """
     results_dir = 'data/results/'
     if folds_to_keep is None:
         folds_to_keep = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -65,6 +170,8 @@ def run(
         frameworks_compare_vs_all=frameworks_compare_vs_all,
         output_dir=benchmark_evaluator.results_dir_output,
     )
+
+    return results_ranked, results_ranked_by_dataset, results_ranked_all, results_ranked_by_dataset_all, results_pairs_merged_dict
 
 
 if __name__ == '__main__':

--- a/autogluon_benchmark/evaluation/runners/run_evaluation_openml.py
+++ b/autogluon_benchmark/evaluation/runners/run_evaluation_openml.py
@@ -1,3 +1,5 @@
+import argparse
+
 from autogluon_benchmark.evaluation import evaluate_results
 from autogluon_benchmark.evaluation.constants import TIME_INFER_S
 from autogluon_benchmark.evaluation.evaluate_utils import compute_stderr_z_stat, compute_stderr_z_stat_bulk, compute_win_rate_per_dataset, graph_vs
@@ -66,217 +68,28 @@ def run(
 
 
 if __name__ == '__main__':
-    frameworks_run = [
-        # 'AutoGluon_bq_1h8c_2022_03_25',  # v0.4.0
-        # 'AutoGluon_bq_1h8c_2022_05_09_rf',  # v0.4.1
-        # 'AutoGluon_hq_1h8c_2022_03_25',  # v0.4.0
-        # 'AutoGluon_bestquality_1h_2021_02_06_v0_1_0',  # v0.1.0
-        # 'AutoGluon_bestquality_1h_2021_09_02',  # v0.3.1
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--paths', type=str, help="Results Paths", required=True, nargs='+')
+    parser.add_argument('--frameworks_run', type=str, help="Name of framework runs", required=True, nargs='+')
+    parser.add_argument('--problem_types', type=str, help="Problem types to evaluate", choices=['binary', 'multiclass', 'regression'], default=['binary', 'multiclass', 'regression'], nargs="+")
+    parser.add_argument('--folds_to_keep', type=int, help="Folds to keep for evaluation", nargs="*")
+    parser.add_argument('--filter_errors', type=bool, help="Filter errors during evaluation", default=False)
+    parser.add_argument('--banned_datasets', type=str, help="Datasets to skip", default=['car', 'kr-vs-kp', 'OnlineNewsPopularity'], nargs='+')
 
-        # 'H2OAutoML_1h8c_2022_03_25',
-        # 'flaml_4h8c_gp3_2022_jmlr',
+    args = parser.parse_args()
 
-        # 'AutoGluon_bq_1h8c_2022_11_14_v06_is',
-        # 'AutoGluon_hq_1h8c_2022_11_14_v06_is',
-        # 'AutoGluon_gq_1h8c_2022_11_14_v06_is',
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_is',
-
-        'AutoGluon_bq_1h8c_2022_11_14_v06_is',
-        'AutoGluon_bq_1h8c_2023_02_14_v07_infer_speed',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_infer_speed',
-
-        # 'AutoGluon_mq_1h8c_2023_02_20_bool',
-        # 'AutoGluon_mq_1h8c_2023_02_20_bool_LightGBM',
-        # 'AutoGluon_mq_1h8c_2023_02_20_bool_test_LightGBM',
-        # 'AutoGluon_mq_1h8c_2023_02_20_bool_test_CatBoost',
-        # 'AutoGluon_bq_1h8c_2023_02_14_v07_sk102_infer_speed',
-
-        # 'AutoGluon_hq_il001_1h8c_2022_11_14_v06_is',
-        # 'AutoGluon_hq_il0005_1h8c_2022_11_14_v06_is',
-
-        # 'AutoGluon_bq_1h8c_2023_02_12_v07_infer_speed',
-        # 'AutoGluon_hq_1h8c_2023_02_12_v07_infer_speed',
-        # 'AutoGluon_gq_1h8c_2023_02_12_v07_infer_speed',
-        # 'AutoGluon_mq_1h8c_2023_02_12_v07_infer_speed',
-
-        # 'AutoGluon_mq_1h8c_2023_02_13_v07_infer_speed',
-        # 'AutoGluon_bq_1h8c_2023_02_14_v07_infer_speed',
-        # 'AutoGluon_hq_1h8c_2023_02_14_v07_infer_speed',
-        # 'AutoGluon_gq_1h8c_2023_02_14_v07_infer_speed',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_infer_speed',
-
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_RandomForestEntr',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_RandomForestEntr',
-
-        # 'AutoGluon_bq_1h8c_2022_11_14_v06_RandomForestEntr_BAG_L1',
-        # 'AutoGluon_bq_1h8c_2023_02_14_v07_RandomForestEntr_BAG_L1',
-
-        # 'AutoGluon_bq_1h8c_2022_11_14_v06_RandomForestGini_BAG_L1',
-        # 'AutoGluon_bq_1h8c_2023_02_14_v07_RandomForestGini_BAG_L1',
-
-        # 'AutoGluon_bq_1h8c_2022_11_14_v06_ExtraTreesEntr_BAG_L1',
-        # 'AutoGluon_bq_1h8c_2023_02_14_v07_ExtraTreesEntr_BAG_L1',
-
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_KNeighborsUnif',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_KNeighborsUnif',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_sk102_KNeighborsUnif',
-
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_ExtraTreesEntr',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_ExtraTreesEntr',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_sk102_ExtraTreesEntr',
-
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_RandomForestEntr',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_RandomForestEntr',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_sk102_RandomForestEntr',
-        #
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_CatBoost',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_CatBoost',
-        # 'AutoGluon_mq_1h8c_2023_02_20_bool_CatBoost',
-        #
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_XGBoost',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_XGBoost',
-        #
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_LightGBM',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_LightGBM',
-        # 'AutoGluon_mq_1h8c_2023_02_20_bool_LightGBM',
-        #
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_NeuralNetTorch',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_NeuralNetTorch',
-        #
-        # 'AutoGluon_mq_1h8c_2022_11_14_v06_NeuralNetFastAI',
-        # 'AutoGluon_mq_1h8c_2023_02_14_v07_NeuralNetFastAI',
-
-        # 'AutoGluon_bq_1h8c_2022_11_14_v06_NeuralNetFastAI_BAG_L1',
-        # 'AutoGluon_bq_1h8c_2023_02_14_v07_NeuralNetFastAI_BAG_L1',
-
-        # 'AutoGluon_bq_1h8c_2023_01_08_v062',
-        # 'AutoGluon_bq_1h8c_2022_12_08_v061',
-        # 'AutoGluon_bestquality_1h8c_2022_05_09',
-        # 'AutoGluon_hq_1h8c_2023_01_08_v062',
-        # 'AutoGluon_gq_1h8c_2023_01_08_v062',
-        # 'AutoGluon_mq_1h8c_2023_01_08_v062',
-        # 'AutoGluon_hq_1h8c_2022_12_08_v061',
-        # 'AutoGluon_gq_1h8c_2022_12_08_v061',
-        # 'AutoGluon_mq_1h8c_2022_12_08_v061',
-
-        # 'EnsembleTrueCV',
-        # 'EnsembleAllHPO',
-        # 'EnsembleAGSimple',
-        # 'AutoGluon_bq_4h64c_2022_11_14_v06_ftt',
-        # 'AutoGluon_hq_4h64c_2022_11_14_v06_ftt',
-        # 'AutoGluon_ebq_4h64c_2022_11_14_v06_ftt',
-        # 'AutoGluon_ehq_4h64c_2022_11_14_v06_ftt',
-        # 'AutoGluon_euq_4h64c_2022_11_14_v06_ftt',
-
-        # 'Ensemble_AG_FTT_all_bq_mytest24h_2022_09_14_v3',
-        # 'Ensemble_AG_FTT_all_bq_cpu_mytest24h_2022_09_14_v3',
-        # 'Ensemble_AG_bq_mytest24h_2022_09_14',
-        # 'Ensemble_AG_FTT_all_bq_mytest4h_2022_09_14_v2',
-        # 'Ensemble_AG_bq_mytest4h_2022_09_14_v2',
-        # 'AutoGluon_bq_1h8c_2022_06_26_binary',
-        # 'AutoGluon_hq_1h8c_2022_06_26_binary',
-        # 'AutoGluon_gq_1h8c_2022_06_26_binary',
-        # 'AutoGluon_mq_1h8c_2022_06_26_binary',
-
-        # 'AutoGluon_benchmark_1h8c_gp3_2022_jmlr',
-        # 'autosklearn_4h8c_gp3_2022_jmlr',
-        # 'autosklearn2_1h8c_gp3_2022_jmlr',
-        # 'flaml_1h8c_gp3_2022_jmlr',
-        # 'GAMA_benchmark_1h8c_gp3_2022_jmlr',
-        # 'H2OAutoML_1h8c_gp3_2022_jmlr',
-    ]
-
-    paths = [
-        'openml_ag_2021_02_06_v0_1_0.csv',  # 10-fold ag 1h
-        'openml_ag_2021_09_02.csv',  # 0.3.1
-        'openml_ag_2022_03_25.csv',  # 1h8c + 4h8c mq gq hq bq AG 0.4 PyPi + other frameworks
-        'openml_ag_2022_05_09.csv',  # 1h8c + 4h8c mq bq 0.4.1
-        'openml_ag_2022_06_26_binary.csv',  # 1h8c bq hq gq mq with binary no stack
-        'openml_ag_2022_06_26_binary_models.csv',  # 1h8c bq hq gq mq with binary no stack
-        'amlb/2022_jmlr.csv',  # gjibers et al
-
-        'openml_ag_2022_09_14.csv',  # Bingzhao
-        'openml_ag_2022_09_14_v2.csv',
-        'openml_ag_2022_09_14_v3.csv',
-
-        'openml_ag_2022_11_14_v06_ftt.csv',  # 4h64c ebq, ehq, eup, bq, hq, 1fold
-        'openml_ag_2022_11_14_v06.csv',  # 1h8c bq, hq, gq, mq, hqi001 hqi0005 hqi0002
-        'openml_ag_2022_11_14_v06_is.csv',
-
-        'zeroshot/zeroshot_EnsembleTrueCV.csv',
-        'zeroshot/zeroshot_EnsembleAllHPO.csv',
-        'zeroshot/zeroshot_EnsembleAGSimple.csv',
-        'openml_ag_2022_10_13_zs_models.csv',
-
-        'openml_ag_2022_12_08_v061.csv',
-        'openml_ag_2023_01_08_v062.csv',
-
-        'openml_ag_2023_02_12_v07_infer_speed.csv',
-        'openml_ag_2023_02_13_v07_infer_speed.csv',  # Accelerated FastAI Preprocessing
-        'openml_ag_2023_02_14_v07_infer_speed.csv',  # Fixed TorchNN time_limit
-
-        'openml_ag_2023_02_14_v07_models.csv',
-        'openml_ag_2022_11_14_v06_models.csv',
-
-        'openml_ag_2023_02_14_v07_sk102_infer_speed.csv',
-        'openml_ag_2023_02_14_v07_sk102_models.csv',
-
-        'openml_ag_2023_02_20_bool.csv',
-        'openml_ag_2023_02_20_bool_models.csv',
-
-        'openml_ag_2023_02_20_bool_test_models.csv',
-
-    ]
-
-    use_tid_as_dataset_name = False
-    # problem_types = ['multiclass']
-    # problem_types = ['binary', 'regression']
-    problem_types = ['binary', 'multiclass', 'regression']
-    treat_folds_as_datasets = False
-    folds_to_keep = [0]
-    # infer_batch_size = 1
-    filter_errors = True
-    infer_batch_size = None
-    banned_datasets = [
-        'car',
-        'kr-vs-kp',
-        'OnlineNewsPopularity',
-    ]
-    # problem_types = ['multiclass']
-    # for problem_type in problem_types:
-    #     run(
-    #         output_suffix=f'2022_amlb_jmlr/1h8c/{problem_type}',
-    #         problem_type=problem_type,
-    #     )
-    #     run(
-    #         output_suffix=f'2022_amlb_jmlr/1h8c_fillna/{problem_type}',
-    #         problem_type=problem_type,
-    #         framework_nan_fill='constantpredictor_1h8c_gp3_2022_jmlr',
-    #     )
     run(
-        paths=paths,
-        frameworks_run=frameworks_run,
-        output_suffix=f'2022_amlb_jmlr/1h8c/all',
-        problem_type=problem_types,
-        treat_folds_as_datasets=treat_folds_as_datasets,
-        # folds_to_keep=folds_to_keep,
-        infer_batch_size=infer_batch_size,
-        filter_errors=filter_errors,
-        use_tid_as_dataset_name=use_tid_as_dataset_name,
-        banned_datasets=banned_datasets,
-        # folds_to_keep=folds_to_keep,
-    )
-    run(
-        paths=paths,
-        frameworks_run=frameworks_run,
-        output_suffix=f'2022_amlb_jmlr/1h8c_fillna/all',
-        framework_nan_fill='constantpredictor_1h8c_gp3_2022_jmlr',
-        problem_type=problem_types,
-        treat_folds_as_datasets=treat_folds_as_datasets,
-        infer_batch_size=infer_batch_size,
-        filter_errors=filter_errors,
-        use_tid_as_dataset_name=use_tid_as_dataset_name,
-        banned_datasets=banned_datasets,
-        # folds_to_keep=folds_to_keep,
+        paths=args.paths,
+        frameworks_run=args.frameworks_run,
+        output_suffix=f'autogluon-bench-text',
+        framework_nan_fill='constantpredictor',
+        problem_type=args.problem_types,
+        treat_folds_as_datasets=False,
+        infer_batch_size=None,
+        filter_errors=args.filter_errors,
+        use_tid_as_dataset_name=False,
+        banned_datasets=args.banned_datasets,
+        folds_to_keep=args.folds_to_keep,
         compute_z_score=False,
     )
+

--- a/autogluon_benchmark/evaluation/runners/run_evaluation_openml_2022_gjibers.py
+++ b/autogluon_benchmark/evaluation/runners/run_evaluation_openml_2022_gjibers.py
@@ -1,75 +1,7 @@
-"""
-TODO: Remove code dupe with `run_evaluation_openml.py`
-"""
-from autogluon_benchmark.evaluation import evaluate_results
-from autogluon_benchmark.evaluation.constants import TIME_INFER_S
-from autogluon_benchmark.evaluation.evaluate_utils import compute_stderr_z_stat, compute_stderr_z_stat_bulk, compute_win_rate_per_dataset, graph_vs
-from autogluon_benchmark.evaluation import BenchmarkEvaluator
-
-
-def run(
-    *,
-    frameworks_run,
-    paths,
-    output_suffix='ag_full_v5/1h8c',
-    framework_nan_fill=None,
-    problem_type=None,
-    folds_to_keep: list = None,
-    compute_z_score=True,
-    treat_folds_as_datasets=False,
-    banned_datasets=None,
-    infer_batch_size=None,
-    clean_data=True,
-    use_tid_as_dataset_name=True,
-    filter_errors=False,  # If True, all dataset errors will be filtered out
-):
-    results_dir = 'data/results/'
-    if folds_to_keep is None:
-        folds_to_keep = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-
-    frameworks_compare_vs_all = []
-    if len(frameworks_compare_vs_all) == 0:
-        frameworks_compare_vs_all = [frameworks_run[0]]
-
-    benchmark_evaluator = BenchmarkEvaluator(
-        results_dir=results_dir,
-        output_suffix=output_suffix,
-        use_tid_as_dataset_name=use_tid_as_dataset_name,
-        framework_nan_fill=framework_nan_fill,
-        filter_errors=filter_errors,
-    )
-
-    results_raw = benchmark_evaluator.load_data(paths=paths,
-                                                frameworks=frameworks_run,
-                                                folds=folds_to_keep,
-                                                clean_data=clean_data,
-                                                problem_type=problem_type,
-                                                banned_datasets=banned_datasets,
-                                                infer_batch_size=infer_batch_size,
-                                                treat_folds_as_datasets=treat_folds_as_datasets)
-
-    folds_to_keep = sorted(results_raw['fold'].unique())
-
-    if len(folds_to_keep) > 1:
-        compute_win_rate_per_dataset(f1=frameworks_run[0], f2=frameworks_run[1], results_raw=results_raw, folds=folds_to_keep)
-    if compute_z_score and len(folds_to_keep) > 1:
-        z_stat_df = compute_stderr_z_stat_bulk(framework=frameworks_run[0], frameworks_to_compare=frameworks_run[1:], results_raw=results_raw)
-        z_stat_series = compute_stderr_z_stat(results_raw, f1=frameworks_run[0], f2=frameworks_run[1], folds=folds_to_keep, verbose=False)
-        graph_vs(results_df=results_raw, f1=frameworks_run[0], f2=frameworks_run[1], z_stats=z_stat_series)
-
-    results_ranked, results_ranked_by_dataset, results_ranked_all, results_ranked_by_dataset_all, results_pairs_merged_dict = evaluate_results.evaluate(
-        results_raw=results_raw,
-        frameworks=frameworks_run,
-        columns_to_agg_extra=[
-            TIME_INFER_S,
-        ],
-        frameworks_compare_vs_all=frameworks_compare_vs_all,
-        output_dir=benchmark_evaluator.results_dir_output,
-    )
+from autogluon_benchmark.evaluation.runners.run_evaluation_openml import run
 
 
 if __name__ == '__main__':
-
     framework_name_suffix = '_4h8c_gp3_2022_jmlr'
     frameworks_run = [
         'AutoGluon_benchmark',

--- a/autogluon_benchmark/evaluation/runners/run_generate_clean_openml.py
+++ b/autogluon_benchmark/evaluation/runners/run_generate_clean_openml.py
@@ -51,157 +51,21 @@ def clean_and_save_results(
 
 
 if __name__ == '__main__':
-    # parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
-    # parser.add_argument('--run_name', type=str, help="Name of run", nargs='?')
-    # parser.add_argument('--file_prefix', type=str, help='Prefix of filename', default='results_automlbenchmark', nargs='?')
-    # parser.add_argument('--constraints', type=list, help='Time constraints', default=None, nargs='?')
-    # parser.add_argument('--out_path_suffix', type=str, help='Suffix added to output file name', default='', nargs='?')
-    #
-    # args = parser.parse_args()
-    #
-    # clean_and_save_results(
-    #     run_name=args.run_name,
-    #     file_prefix=args.file_prefix,
-    #     constraints=args.constraints,
-    #     out_path_suffix=args.out_path_suffix,
-    # )
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('--run_name', type=str, help="Name of run", nargs='?')
+    parser.add_argument('--file_prefix', type=str, help='Prefix of filename', nargs='?')
+    parser.add_argument('--results_input_dir', type=str, help='Results input directory', nargs='?')
+    parser.add_argument('--constraints', type=list, help='Time constraints', default=None, nargs='?')
+    parser.add_argument('--run_name_in_input_path', type=str, help='Run name in input path', default=False, nargs='?')
+    parser.add_argument('--out_path_suffix', type=str, help='Suffix added to output file name', default='', nargs='?')
 
-    # run_name_arg = '2022_06_19'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_06_21'
-    # clean_and_save_results(run_name_arg, constraints=['4h64c'])
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='results_ag_leaderboard',
-    #     constraints=['4h64c'],
-    #     out_path_suffix='_models'
-    # )
-    # run_name_arg = '2022_07_26_i001'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_07_26_i001_2'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_07_26_saveall'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_06_26_binary'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_07_30'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_07_31_i01'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_07_31_i005'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_07_31_i002'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_09_30_gbm_zs'
-    # # clean_and_save_results(run_name_arg, constraints=['8h8c'])
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='results_ag_leaderboard',
-    #     constraints=['8h8c'],
-    #     out_path_suffix='_models'
-    # )
-    # run_name_arg = '2022_09_30_cat_zs'
-    # # clean_and_save_results(run_name_arg, constraints=['16h8c'])
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='results_ag_leaderboard',
-    #     constraints=['16h8c'],
-    #     out_path_suffix='_models'
-    # )
-    # run_name_arg = '2022_10_02_zs'
-    # # clean_and_save_results(run_name_arg, constraints=['16h8c'])
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='results_ag_leaderboard',
-    #     constraints=['16h8c'],
-    #     out_path_suffix='_models'
-    # )
-    # run_name_arg = '2022_07_12_torch'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2022_09_14_v3'
-    # clean_and_save_results(run_name_arg, constraints=['mytest24h'])
+    args = parser.parse_args()
 
-    # run_name_arg = '2022_11_14_v06_ftt'
-    # clean_and_save_results(run_name_arg, constraints=['4h64c'])
-    # run_name_arg = '2023_01_08_v062'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-    # run_name_arg = '2023_02_14_v07_infer_speed'
-    # clean_and_save_results(run_name_arg, constraints=['1h8c'])
-
-    run_name_arg = '2023_02_27_zs'
-    path_prefix = f's3://automl-benchmark-ag/aggregated/ec2/2023_02_27_zs/'
-    clean_and_save_results(run_name_arg,
-                           file_prefix='results',
-                           results_dir_input=path_prefix,
-                           run_name_in_input_path=False,
-                           )
     clean_and_save_results(
-        run_name_arg,
-        results_dir_input=path_prefix,
-        file_prefix='leaderboard',
-        out_path_suffix='_models',
-        run_name_in_input_path=False,
+        args.run_name,
+        file_prefix=args.file_prefix,
+        results_dir_input=args.results_input_dir,
+        constraints=args.constraints,
+        run_name_in_input_path=args.run_name_in_input_path
     )
-
-    run_name_arg = '2023_02_27_zs'
-    path_prefix = f's3://automl-benchmark-ag/aggregated/ec2/2023_02_27_zs/'
-    clean_and_save_results(run_name_arg,
-                           file_prefix='results',
-                           results_dir_input=path_prefix,
-                           run_name_in_input_path=False,
-                           )
-    clean_and_save_results(
-        run_name_arg,
-        results_dir_input=path_prefix,
-        file_prefix='leaderboard',
-        out_path_suffix='_models',
-        run_name_in_input_path=False,
-    )
-
-    # run_name_arg = '2023_02_14_v07'
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='results_ag_leaderboard',
-    #     constraints=['1h8c'],
-    #     out_path_suffix='_models'
-    # )
-    # run_name_arg = '2023_02_14_v07_sk102'
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='results_ag_leaderboard',
-    #     constraints=['1h8c'],
-    #     out_path_suffix='_models'
-    # )
-    # run_name_arg = '2022_jmlr'
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='amlb_jmlr_2022/amlb',
-    #     constraints=['all'],
-    #     out_path_prefix='amlb/',
-    #     framework_suffix_column='constraint'
-    # )
-
-    # run_name_arg = '2022_10_13_zs'
-    # # clean_and_save_results(run_name_arg, constraints=['16h8c'])
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='results_ag_leaderboard',
-    #     constraints=['16h8c'],
-    #     out_path_suffix='_models'
-    # )
-    # run_name_arg = '2022_06_26_binary'
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='results_ag_leaderboard',
-    #     constraints=['1h8c'],
-    #     out_path_suffix='_models'
-    # )
-    #
-    # run_name_arg = '2022_06_26_binary'
-    # clean_and_save_results(
-    #     run_name_arg,
-    #     file_prefix='results_ag_leaderboard',
-    #     constraints=['1h8c'],
-    #     out_path_suffix='_models'
-    # )
 

--- a/scripts/aggregate_openml_results.py
+++ b/scripts/aggregate_openml_results.py
@@ -9,15 +9,9 @@ if __name__ == '__main__':
                         default='automl-benchmark-ag', nargs='?')
     parser.add_argument('--s3_prefix', type=str, help='Prefix for path to results needing aggregation', default='ec2/', nargs='?')
     parser.add_argument('--version_name', type=str, help='Root folder name in EC2 of results', nargs='?')
-    parser.add_argument('--constraint', type=str, help='Name of constraint used in benchmark', default='1h8c', nargs='?')
+    parser.add_argument('--constraint', type=str, help='Name of constraint used in benchmark', default=None, nargs='?')
     parser.add_argument('--include_infer_speed', action='store_true')
-    parser.add_argument('--no-include_infer_speed', dest='include_infer_speed', action='store_false')
-    parser.add_argument('--mode', type=str, help='Whether to aggregate via "seq" or via "ray"', default='ray',
-                        nargs='?')
-    parser.set_defaults(keep_params=True)
-    parser.set_defaults(include_infer_speed=False)
-    parser.set_defaults(version_name="2023_03_19_zs")  # FIXME: Remove
-    parser.set_defaults(constraint="24h64c")  # FIXME: Remove
+    parser.add_argument('--mode', type=str, help='Whether to aggregate via "seq" or via "ray"', default='ray', nargs='?')
     args = parser.parse_args()
 
     aggregate_results(


### PR DESCRIPTION
This PR captures the changes I made when adding eval logic to `autogluon/autogluon-bench`. Some changes don't translate well because file paths change in the new repo. This resulted in import differences in the following files:

autogluon_benchmark/aggregate/results.py
autogluon_benchmark/benchmark_context/_output_suite_context.py
autogluon_benchmark/benchmark_context/_output_suite_context.py
autogluon_benchmark/evaluation/evaluator/benchmark_evaluator.py
autogluon_benchmark/evaluation/runners/run_evaluation_openml.py
autogluon_benchmark/evaluation/runners/run_generate_clean_openml.py
scripts/aggregate_openml_results.py